### PR TITLE
Improve YouTube queue handling and shuffle flow

### DIFF
--- a/discobot.py
+++ b/discobot.py
@@ -5,6 +5,7 @@ import yt_dlp as youtube_dl
 import asyncio
 from dotenv import load_dotenv
 import re
+import random
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
@@ -45,7 +46,6 @@ bot = commands.Bot(command_prefix='::', intents=intents)
 song_queue = []
 shuffle_mode = False
 shuffle_results = []
-current_shuffle_index = 0
 volume_level = 1.0  # Default volume level (100%)
 executor = ThreadPoolExecutor(max_workers=5)
 
@@ -58,6 +58,37 @@ def shorten_url(url: str) -> str:
 async def run_blocking_task(task: Callable, *args, **kwargs):
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(executor, task, *args, **kwargs)
+
+
+async def fetch_info(query: str) -> dict:
+    def _extract():
+        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+            return ydl.extract_info(query, download=False)
+
+    return await run_blocking_task(_extract)
+
+
+def build_queue_entries(info: dict) -> list[dict]:
+    if 'entries' not in info:
+        return [{
+            'url': info.get('webpage_url') or info.get('url'),
+            'title': info.get('title') or 'Unknown title',
+        }]
+
+    entries = [entry for entry in info['entries'] if entry]
+    if info.get('_type') == 'playlist':
+        return [{
+            'url': entry.get('webpage_url') or entry.get('url'),
+            'title': entry.get('title') or 'Unknown title',
+        } for entry in entries if entry.get('webpage_url') or entry.get('url')]
+
+    if entries:
+        entry = entries[0]
+        return [{
+            'url': entry.get('webpage_url') or entry.get('url'),
+            'title': entry.get('title') or 'Unknown title',
+        }]
+    return []
 
 
 @bot.command()
@@ -90,15 +121,17 @@ async def play(ctx, *, query: str):
             return
 
     try:
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(query, download=False)
-            if 'entries' in info:
-                url = info['entries'][0]['url']
-            else:
-                url = info['url']
+        info = await fetch_info(query)
+        entries = build_queue_entries(info)
+        if not entries:
+            await ctx.send("No results found.")
+            return
 
-        song_queue.append(url)
-        await ctx.send(f"Added to queue: {shorten_url(url)}")
+        song_queue.extend(entries)
+        if len(entries) == 1:
+            await ctx.send(f"Added to queue: {entries[0]['title']} ({shorten_url(entries[0]['url'])})")
+        else:
+            await ctx.send(f"Added {len(entries)} tracks to the queue.")
         if not ctx.voice_client.is_playing():
             await play_next(ctx)
     except Exception as e:
@@ -107,28 +140,38 @@ async def play(ctx, *, query: str):
 
 
 async def play_next(ctx):
+    global shuffle_mode, shuffle_results
+    if shuffle_mode:
+        if not shuffle_results:
+            shuffle_mode = False
+            await ctx.send("Shuffle complete.")
+            return
+        entry = shuffle_results.pop(0)
+        await play_song(ctx, entry)
+        return
+
     if song_queue:
-        url = song_queue.pop(0)
-        await play_song(ctx, url)
+        entry = song_queue.pop(0)
+        await play_song(ctx, entry)
 
 
-async def play_song(ctx, url):
+async def play_song(ctx, entry: dict):
     async with ctx.typing():
-        loop = asyncio.get_running_loop()
         vc = ctx.voice_client
 
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(url, download=False)
-            audio_url = next((f['url'] for f in info['formats'] if f.get('acodec') != 'none'), None)
-            if not audio_url:
-                await ctx.send("Error: No valid audio found.")
-                return
+        info = await fetch_info(entry['url'])
+        audio_url = info.get('url')
+        if not audio_url:
+            audio_url = next((f['url'] for f in info.get('formats', []) if f.get('acodec') != 'none'), None)
+        if not audio_url:
+            await ctx.send("Error: No valid audio found.")
+            return
 
         source = discord.FFmpegPCMAudio(audio_url, **FFMPEG_OPTIONS)
         source = discord.PCMVolumeTransformer(source, volume=volume_level)
 
         vc.play(source, after=lambda _: asyncio.run_coroutine_threadsafe(play_next(ctx), bot.loop))
-        await ctx.send(f"Now playing: {shorten_url(url)}")
+        await ctx.send(f"Now playing: {entry['title']} ({shorten_url(entry['url'])})")
 
 
 @bot.command()
@@ -143,7 +186,7 @@ async def skip(ctx):
 @bot.command()
 async def queue(ctx):
     if song_queue:
-        queue_list = '\n'.join([shorten_url(song) for song in song_queue])
+        queue_list = '\n'.join([f"{song['title']} ({shorten_url(song['url'])})" for song in song_queue])
         await ctx.send(f"**Song Queue:**\n{queue_list}")
     else:
         await ctx.send("Queue is empty.")
@@ -163,24 +206,28 @@ async def volume(ctx, level: int):
 
 @bot.command()
 async def shuffle(ctx):
-    global shuffle_mode, shuffle_results, current_shuffle_index
+    global shuffle_mode, shuffle_results
     if not song_queue:
         await ctx.send("The queue is empty.")
         return
     shuffle_mode = True
     shuffle_results = song_queue[:]
-    current_shuffle_index = 0
+    song_queue.clear()
+    random.shuffle(shuffle_results)
     await ctx.send("Shuffle mode activated.")
     await play_next(ctx)
 
 
 @bot.command()
 async def shufflestop(ctx):
-    global shuffle_mode
+    global shuffle_mode, shuffle_results
     if not shuffle_mode:
         await ctx.send("Shuffle mode is not active.")
         return
     shuffle_mode = False
+    if shuffle_results:
+        song_queue[:0] = shuffle_results
+        shuffle_results = []
     await ctx.send("Shuffle mode stopped.")
 
 


### PR DESCRIPTION
### Motivation
- Prevent blocking the event loop during `yt-dlp` lookups and make search/playlist results consistent for the queue.
- Provide clearer user feedback by storing titles with queue entries and improving "now playing"/`queue` messages.
- Fix shuffle behavior so playback actually randomizes and remaining items are restored when shuffle stops.

### Description
- Added `fetch_info` to run `yt-dlp` extraction in a background executor and `build_queue_entries` to normalize single videos, search results, and playlists into a list of `{url, title}` entries.
- Switched `song_queue` to store entry dictionaries and updated `play`, `play_next`, `play_song`, and `queue` commands to use the new entry shape and show readable titles with shortened URLs.
- Implemented shuffle mode to move the current `song_queue` into `shuffle_results`, `random.shuffle` it, clear the main queue during shuffle, and play from `shuffle_results` until exhausted.
- Restored remaining shuffled items back into the front of `song_queue` when `shufflestop` is called.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69742d210c80832e8f4f1357cf1059ad)