### PR TITLE
Add `ensure_voice` helper to guard and retry voice connections

### DIFF
--- a/discobot.py
+++ b/discobot.py
@@ -93,6 +93,35 @@ def build_queue_entries(info: dict) -> list[dict]:
     return []
 
 
+async def ensure_voice(ctx) -> bool:
+    if ctx.voice_client and ctx.voice_client.is_connected():
+        return True
+
+    if not ctx.author.voice or not ctx.author.voice.channel:
+        await ctx.send("You need to be in a voice channel first.")
+        return False
+
+    channel = ctx.author.voice.channel
+    last_error = None
+    for attempt in range(VOICE_CONNECT_RETRIES):
+        try:
+            await channel.connect()
+            return True
+        except discord.ClientException:
+            if ctx.voice_client and ctx.voice_client.is_connected():
+                return True
+            last_error = "Connection already in progress."
+        except Exception as exc:
+            last_error = str(exc)
+        await asyncio.sleep(VOICE_CONNECT_DELAY)
+
+    message = "I couldn't connect to the voice channel."
+    if last_error:
+        message = f"{message} ({last_error})"
+    await ctx.send(message)
+    return False
+
+
 @bot.command()
 async def join(ctx):
     await ensure_voice(ctx)


### PR DESCRIPTION
### Motivation
- Fix a runtime `NameError` and improve voice command reliability by validating the caller's voice state and handling connection failures.

### Description
- Add an `ensure_voice(ctx) -> bool` helper that checks `ctx.voice_client`, verifies the command author is in a voice channel, and attempts to connect with retry logic using `VOICE_CONNECT_RETRIES` and `VOICE_CONNECT_DELAY`.
- Provide user-facing error messages when the user is not in a channel or when the bot cannot connect, and return a boolean success flag to callers.
- Use the new helper from `join` (and existing `play` usage now resolves the previously missing reference).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974308c60e0832eb031a4d1d76cc48a)